### PR TITLE
Bump Gitpod workspace image tag

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full:2024-01-24-09-19-42
                     
 USER gitpod
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,6 +6,6 @@ tasks:
     ./bootstrap.sh &&
     ./configure &&
     cd - &&
-    bear make
+    bear -- make
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
Explicitly specify the latest currently available tag, this resolves the issue with certificate verification when cloning Zabbix repository. This should also help with reproducibility.

Also the new image has a newer version of Bear, so a command needed an update.